### PR TITLE
[CB-4950] Remove the dependence on concrete component android.webkit.WebView.

### DIFF
--- a/src/android/ContactAccessor.java
+++ b/src/android/ContactAccessor.java
@@ -19,7 +19,6 @@ package org.apache.cordova.contacts;
 import java.util.HashMap;
 
 import android.util.Log;
-import android.webkit.WebView;
 
 import org.apache.cordova.CordovaInterface;
 import org.json.JSONArray;
@@ -37,7 +36,6 @@ public abstract class ContactAccessor {
 
     protected final String LOG_TAG = "ContactsAccessor";
     protected CordovaInterface mApp;
-    protected WebView mView;
 
     /**
      * Check to see if the data associated with the key is required to

--- a/src/android/ContactAccessorSdk5.java
+++ b/src/android/ContactAccessorSdk5.java
@@ -31,7 +31,6 @@ import android.net.Uri;
 import android.os.RemoteException;
 import android.provider.ContactsContract;
 import android.util.Log;
-import android.webkit.WebView;
 
 import org.apache.cordova.CordovaInterface;
 import org.json.JSONArray;
@@ -124,9 +123,8 @@ public class ContactAccessorSdk5 extends ContactAccessor {
     /**
      * Create an contact accessor.
      */
-    public ContactAccessorSdk5(WebView view, CordovaInterface context) {
+    public ContactAccessorSdk5(CordovaInterface context) {
         mApp = context;
-        mView = view;
     }
 
     /**

--- a/src/android/ContactManager.java
+++ b/src/android/ContactManager.java
@@ -68,7 +68,7 @@ public class ContactManager extends CordovaPlugin {
          * older phones.
          */
         if (this.contactAccessor == null) {
-            this.contactAccessor = new ContactAccessorSdk5(this.webView, this.cordova);
+            this.contactAccessor = new ContactAccessorSdk5(this.cordova);
         }
 
         if (action.equals("search")) {


### PR DESCRIPTION
The android implementation of contacts plugin depends on the concrete web infrastructure android.webkit.WebView.  This dependence ruins the portability of the plugin. For example, it could not run on a substantial implementation of CordovaWebView which based on a android third party component(such as chromium for android).
