### PR TITLE
Switch Contact ID lookup to use Raw contact id.

### DIFF
--- a/src/android/ContactAccessorSdk5.java
+++ b/src/android/ContactAccessorSdk5.java
@@ -284,9 +284,9 @@ public class ContactAccessorSdk5 extends ContactAccessor {
         // Do the id query
         Cursor c = mApp.getActivity().getContentResolver().query(ContactsContract.Data.CONTENT_URI,
                 null,
-                ContactsContract.Data.CONTACT_ID + " = ? ",
+                ContactsContract.Data.RAW_CONTACT_ID + " = ? ",
                 new String[] { id },
-                ContactsContract.Data.CONTACT_ID + " ASC");
+                ContactsContract.Data.RAW_CONTACT_ID + " ASC");
 
         JSONArray fields = new JSONArray();
         fields.put("*");


### PR DESCRIPTION
When saving a contact it is the raw contact ID that is returned and so the check in ContactManager after the save needs to be using that.  This requires this change to work on 4.3/4.2.
