### PR TITLE
[firefoxos] CB-3208 lots of changes

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -277,6 +277,12 @@ for details.
 
 - __urls__:  Partially supported. The first URL is stored in BlackBerry __webpage__ field.
 
+### FirefoxOS Quirks
+
+- __categories__: Partially supported. Fields __pref__ and __type__ are returning `null`
+
+- __organizations__: Partially supported. Fields __pref__, __type__ and __department__ are returning `null`. Fields __name__ and __title__ stored in __org__ and __jobTitle__.
+
 ### iOS Quirks
 
 - __displayName__: Not supported on iOS, returning `null` unless there is no `ContactName` specified, in which case it returns the composite name, __nickname__ or `""`, respectively.
@@ -394,6 +400,10 @@ a `ContactAddress[]` array.
 - __postalCode__: Supported.  Stored in BlackBerry __zipPostal__ address field.
 
 - __country__: Supported.
+
+### FirefoxOS Quirks
+
+- __formatted__: Currently not supported
 
 ### iOS Quirks
 
@@ -555,6 +565,10 @@ Contains different kinds of information about a `Contact` object's name.
 - __honorificPrefix__: Not supported, returning `null`.
 
 - __honorificSuffix__: Not supported, returning `null`.
+
+### FirefoxOS Quirks
+
+- __formatted__: Partially supported, and read-only.  Returns a concatenation of `honorificPrefix`, `givenName`, `middleName`, `familyName`, and `honorificSuffix`.
 
 ### iOS Quirks
 

--- a/src/firefoxos/ContactsProxy.js
+++ b/src/firefoxos/ContactsProxy.js
@@ -196,16 +196,17 @@ Contact.prototype.updateFromMozilla = function(moz) {
         return organizations;
     }
 
-    function createFormatted(cordova) {
+    function createFormatted(name) {
+        var fields = ['honorificPrefix', 'givenName', 'middleName', 
+                      'familyName', 'honorificSuffix'];
         var f = '';
-        if (cordova.name.givenName) {
-            f = cordova.name.givenName;
-        }
-        if (cordova.name.familyName) {
-            if (f) {
-                f += ' ';
+        for (var i = 0; i < fields.length; i++) {
+            if (name[fields[i]]) {
+                if (f) {
+                    f += ' ';
+                }
+                f += name[fields[i]];
             }
-            f += cordova.name.familyName;
         }
         return f;
     }
@@ -264,7 +265,7 @@ Contact.prototype.updateFromMozilla = function(moz) {
         this.organizations = createOrganizations(moz.org, moz.jobTitle);
     }
     // construct a read-only formatted value
-    this.name.formatted = createFormatted(this);
+    this.name.formatted = createFormatted(this.name);
 
     /*  Find out how to translate these parameters
         // photo: Blob


### PR DESCRIPTION
Tests needed to be changed as FFOS requires a specific construction of "privileged" apps.
All javascript code needs to be placed in separate file.

""" (comment on jira CB-3208)
I needed to modify the tests as well to make it work under FFOS (type privilleged is required which bans inline javascript)
https://github.com/zalun/cordova-mobile-spec
I've been working on automated tests only.
I modified test 20 so it's deleting the gContactObj as 21 is no longer depending on its creation.
21 is now testing returned (from save) fields like addresses, organizations and categories.
