### PR TITLE
Check to see if photoData exists before using

### DIFF
--- a/src/ios/CDVContact.m
+++ b/src/ios/CDVContact.m
@@ -1326,6 +1326,10 @@ static NSDictionary* org_apache_cordova_contacts_defaultFields = nil;
 
     if (ABPersonHasImageData(self.record)) {
         CFDataRef photoData = ABPersonCopyImageData(self.record);
+        if (!photoData) {
+            return;
+        }
+        
         NSData* data = (__bridge NSData*)photoData;
         // write to temp directory and store URI in photos array
         // get the temp directory path


### PR DESCRIPTION
Fix for the following issue:

https://issues.apache.org/jira/browse/CB-5698?filter=-2

Crash when accessing a corrupt image. This crash occurs when ABPersonHasImageData() returns true while ABPersonCopyImageData() returns nil.
