### PR TITLE
Auto-managing permissions

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -42,22 +42,6 @@ contact data.  For more information, please see the Privacy Guide.
 
     cordova plugin add org.apache.cordova.contacts
 
-### Firefox OS Quirks
-
-Create __www/manifest.webapp__ as described in 
-[Manifest Docs](https://developer.mozilla.org/en-US/Apps/Developing/Manifest).
-Add relevant permisions.
-There is also a need to change the webapp type to "privileged"  - [Manifest Docs](https://developer.mozilla.org/en-US/Apps/Developing/Manifest#type).
-__WARNING__: All privileged apps enforce [Content Security Policy](https://developer.mozilla.org/en-US/Apps/CSP) which forbids inline script. Initialize your application in another way.
-
-	"type": "privileged",
-	"permissions": {
-		"contacts": {
-			"access": "readwrite",
-			"description": "Describe why there is a need for such permission"
-		}
-	}
-
 ## navigator.contacts
 
 ### Methods

--- a/plugin.xml
+++ b/plugin.xml
@@ -198,10 +198,9 @@
     <!-- firefoxos -->
     <platform name="firefoxos">
         <config-file target="config.xml" parent="/*">
-            <feature name="Contacts">
-                <param name="firefoxos-package" value="Contacts" />
-            </feature>
-        </config-file>                                         
+            <permission name="contacts" access="readwrite" description="Required for accessing address book."
+                        privileged="true"/>
+        </config-file>
         <js-module src="src/firefoxos/ContactsProxy.js" name="ContactsProxy">
             <runs />
         </js-module>


### PR DESCRIPTION
With [CB-5416](https://github.com/apache/cordova-cli/pull/168) merged, we can have plugins automatically set the permissions in the manifest.
