### PR TITLE
Removing a stray unicode character

### DIFF
--- a/www/ContactFieldType.js
+++ b/www/ContactFieldType.js
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
There was a character hiding at the start of this file that only shows up if you read it with the right encoding. Loading the contacts javascript module broke on iOS in my usage because of this.
