### PR TITLE
Removed [optional] tag from contactFindOptions. Fixes #CB-7247

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -128,7 +128,7 @@ parameter to control which contact properties must be returned back.
 
 - __contactFields__: Contact fields to use as a search qualifier. _(DOMString[])_ [Required]
 
-- __contactFindOptions__: Search options to filter navigator.contacts. [Optional] Keys include:
+- __contactFindOptions__: Search options to filter navigator.contacts. Keys include:
 
 - __filter__: The search string used to find navigator.contacts. _(DOMString)_ (Default: `""`)
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-7247
The parameter contactFindOptions of navigator.contacts.find is labeled optional but actually is required.
