### PR TITLE
Making sure the photoCursor is always closed

### DIFF
--- a/src/android/ContactAccessorSdk5.java
+++ b/src/android/ContactAccessorSdk5.java
@@ -908,14 +908,12 @@ public class ContactAccessorSdk5 extends ContactAccessor {
 
             // Query photo existance
             Cursor photoCursor = mApp.getActivity().getContentResolver().query(photoUri, new String[] {ContactsContract.Contacts.Photo.PHOTO}, null, null, null);
-            if (photoCursor == null) {
+            if (photoCursor == null) return null;
+            if (!photoCursor.moveToFirst()) {
+                photoCursor.close();
                 return null;
-            } else {
-                if (!photoCursor.moveToFirst()) {
-                    photoCursor.close();
-                    return null;
-                }
             }
+            photoCursor.close();
         } catch (JSONException e) {
             Log.e(LOG_TAG, e.getMessage(), e);
         }


### PR DESCRIPTION
Sometimes the app would crash with the following error:
```android.database.CursorWindowAllocationException: Cursor window could not be created from binder``` 
The stacktrace points to `ContactAccessorSdk5.java:910`

According to [this StackOverflow thread](http://stackoverflow.com/a/21221016) this is due to a cursor not being closed correctly. Indeed, if `photoCursor.moveToFirst()` returns true, `photoCursor.close()` was never called.

This patch tackles this case.

