### PR TITLE
CB-9078 Android - Filter search: hasPhoneNumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ parameter to control which contact properties must be returned back.
 
     - __desiredFields__: Contact fields to be returned back. If specified, the resulting `Contact` object only features values for these fields. _(DOMString[])_ [Optional]
 
-    - __hasPhoneNumber__(Android only): Filters the search to only return contacts with a phone number informed. _(Boolean)_ [Optional] (Default: `false`)
+    - __hasPhoneNumber__(Android only): Filters the search to only return contacts with a phone number informed. _(Boolean)_ (Default: `false`)
 
 ### Supported Platforms
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ parameter to control which contact properties must be returned back.
 
 	- __multiple__: Determines if the find operation returns multiple navigator.contacts. _(Boolean)_ (Default: `false`)
 
-    	- __desiredFields__: Contact fields to be returned back. If specified, the resulting `Contact` object only features values for these fields. _(DOMString[])_ [Optional]
+    - __desiredFields__: Contact fields to be returned back. If specified, the resulting `Contact` object only features values for these fields. _(DOMString[])_ [Optional]
+
+    - __hasPhoneNumber__(Android only): Filters the search to only return contacts with a phone number informed. _(boolean)_ [Optional]
 
 ### Supported Platforms
 
@@ -187,6 +189,7 @@ parameter to control which contact properties must be returned back.
     options.filter   = "Bob";
     options.multiple = true;
     options.desiredFields = [navigator.contacts.fieldType.id];
+    options.hasPhoneNumber = true;
     var fields       = [navigator.contacts.fieldType.displayName, navigator.contacts.fieldType.name];
     navigator.contacts.find(fields, onSuccess, onError, options);
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ parameter to control which contact properties must be returned back.
 
     - __desiredFields__: Contact fields to be returned back. If specified, the resulting `Contact` object only features values for these fields. _(DOMString[])_ [Optional]
 
-    - __hasPhoneNumber__(Android only): Filters the search to only return contacts with a phone number informed. _(boolean)_ [Optional]
+    - __hasPhoneNumber__(Android only): Filters the search to only return contacts with a phone number informed. _(Boolean)_ [Optional] (Default: `false`)
 
 ### Supported Platforms
 

--- a/www/ContactFindOptions.js
+++ b/www/ContactFindOptions.js
@@ -26,10 +26,11 @@
  * @param multiple boolean used to determine if more than one contact should be returned
  */
 
-var ContactFindOptions = function(filter, multiple, desiredFields) {
+var ContactFindOptions = function(filter, multiple, desiredFields, phoneNumberInformedOnly) {
     this.filter = filter || '';
     this.multiple = (typeof multiple != 'undefined' ? multiple : false);
     this.desiredFields = typeof desiredFields != 'undefined' ? desiredFields : [];
+    this.phoneNumberInformedOnly = typeof phoneNumberInformedOnly != 'undefined' ? phoneNumberInformedOnly : false;
 };
 
 module.exports = ContactFindOptions;

--- a/www/ContactFindOptions.js
+++ b/www/ContactFindOptions.js
@@ -24,13 +24,15 @@
  * @constructor
  * @param filter used to match contacts against
  * @param multiple boolean used to determine if more than one contact should be returned
+ * @param desiredFields 
+ * @param hasPhoneNumber boolean used to filter the search and only return contacts that have a phone number informed
  */
 
-var ContactFindOptions = function(filter, multiple, desiredFields, phoneNumberInformedOnly) {
+var ContactFindOptions = function(filter, multiple, desiredFields, hasPhoneNumber) {
     this.filter = filter || '';
     this.multiple = (typeof multiple != 'undefined' ? multiple : false);
     this.desiredFields = typeof desiredFields != 'undefined' ? desiredFields : [];
-    this.phoneNumberInformedOnly = typeof phoneNumberInformedOnly != 'undefined' ? phoneNumberInformedOnly : false;
+    this.hasPhoneNumber = typeof hasPhoneNumber != 'undefined' ? hasPhoneNumber : false;
 };
 
 module.exports = ContactFindOptions;


### PR DESCRIPTION
When searching for all the contacts in Android, by default all the google contacts(Gmail history, etc...) are returned. This causes performance problems when the number of contacts is big.

Usually, we only want contacts that have a phone number informed. I have addes a new optional boolean parameter to the options object of the "find" method: "phoneNumberInformedOnly"

If we send true in this parameter, the where clause of the select to the contacts database will include:
      
      "AND (" + ContactsContract.Contacts.HAS_PHONE_NUMBER + " = 1)"
      
This filter is also added if a filter string is sent to the search method.

Use case:

    // find all contacts with 'Bob' in any name field
    var options      = new ContactFindOptions();
    options.multiple = true;
    options.phoneNumberInformedOnly = true;
    options.desiredFields = [navigator.contacts.fieldType.id];
    var fields       = [navigator.contacts.fieldType.displayName, navigator.contacts.fieldType.name];
    navigator.contacts.find(fields, onSuccess, onError, options);