### PR TITLE
Do not return absolute path for contact images.

### DIFF
--- a/src/windows/ContactProxy.js
+++ b/src/windows/ContactProxy.js
@@ -106,10 +106,10 @@ function convertToContact(windowsContact) {
         contact.note = contactNotes;
     }
 
-    // thumbnail field available on Windows 8.1/WP8.1 only
+    // returned is a file, a blob url can be made 
     var contactPhoto = windowsContact.thumbnail;
     if (contactPhoto && contactPhoto.path) {
-        contact.photos = [new ContactField(null, contactPhoto.path , false)];
+        contact.photos = [new ContactField(null, URL.createObjectURL(contactPhoto) , false)];
     }
 
     return contact;

--- a/src/windows/ContactProxy.js
+++ b/src/windows/ContactProxy.js
@@ -109,7 +109,7 @@ function convertToContact(windowsContact) {
     // returned is a file, a blob url can be made 
     var contactPhoto = windowsContact.thumbnail;
     if (contactPhoto && contactPhoto.path) {
-        contact.photos = [new ContactField(null, URL.createObjectURL(contactPhoto) , false)];
+        contact.photos = [new ContactField('url', URL.createObjectURL(contactPhoto) , false)];
     }
 
     return contact;


### PR DESCRIPTION
If an absolute url is returned the developer must use the file system api to get a reference to the image, instead returning a blob url makes more sense, and it seems more logical.