### PR TITLE
Return rawId

### DIFF
--- a/src/android/ContactAccessorSdk5.java
+++ b/src/android/ContactAccessorSdk5.java
@@ -1458,9 +1458,9 @@ public class ContactAccessorSdk5 extends ContactAccessor {
             retVal = false;
         }
 
-        // if the save was a success return the contact ID
+        // if the save was a success return the contact RAW_ID
         if (retVal) {
-            return id;
+            return Integer.toString(rawId);
         } else {
             return null;
         }


### PR DESCRIPTION
contactAccessor.getContactById() actually expects the contact rawId