### PR TITLE
CB-8156 Call error callback on pickContact cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@ The `ContactError` object is returned to the user through the
 - `ContactError.PENDING_OPERATION_ERROR` (code 3)
 - `ContactError.IO_ERROR` (code 4)
 - `ContactError.NOT_SUPPORTED_ERROR` (code 5)
+- `ContactError.OPERATION_CANCELLED_ERROR` (code 6)
 - `ContactError.PERMISSION_DENIED_ERROR` (code 20)
 
 

--- a/src/android/ContactManager.java
+++ b/src/android/ContactManager.java
@@ -52,6 +52,7 @@ public class ContactManager extends CordovaPlugin {
     public static final int PENDING_OPERATION_ERROR = 3;
     public static final int IO_ERROR = 4;
     public static final int NOT_SUPPORTED_ERROR = 5;
+    public static final int OPERATION_CANCELLED_ERROR = 6;
     public static final int PERMISSION_DENIED_ERROR = 20;
     private static final int CONTACT_PICKER_RESULT = 1000;
     public static String [] permissions;
@@ -246,10 +247,11 @@ public class ContactManager extends CordovaPlugin {
                 } catch (JSONException e) {
                     Log.e(LOG_TAG, "JSON fail.", e);
                 }
-            } else if (resultCode == Activity.RESULT_CANCELED){
-                this.callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.NO_RESULT, UNKNOWN_ERROR));
+            } else if (resultCode == Activity.RESULT_CANCELED) {
+                callbackContext.error(OPERATION_CANCELLED_ERROR);
                 return;
             }
+
             this.callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, UNKNOWN_ERROR));
         }
     }

--- a/src/ios/CDVContact.h
+++ b/src/ios/CDVContact.h
@@ -28,6 +28,7 @@ enum CDVContactError {
     PENDING_OPERATION_ERROR = 3,
     IO_ERROR = 4,
     NOT_SUPPORTED_ERROR = 5,
+    OPERATION_CANCELLED_ERROR = 6,
     PERMISSION_DENIED_ERROR = 20
 };
 typedef NSUInteger CDVContactError;

--- a/src/ios/CDVContacts.m
+++ b/src/ios/CDVContacts.m
@@ -233,7 +233,7 @@
     NSNumber* recordId = picker.pickedContactDictionary[kW3ContactId];
     
     if ([recordId isEqualToNumber:[NSNumber numberWithInt:kABRecordInvalidID]]) {
-        result = [CDVPluginResult resultWithStatus:CDVCommandStatus_NO_RESULT];
+        result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsInt:OPERATION_CANCELLED_ERROR] ;
     } else {
         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:picker.pickedContactDictionary];
     }

--- a/src/windows/ContactProxy.js
+++ b/src/windows/ContactProxy.js
@@ -242,7 +242,9 @@ module.exports = {
         pickRequest.done(function (contact) {
             // if contact was not picked
             if (!contact) {
-                fail && fail(new Error("User did not pick a contact."));
+                var cancelledError = new ContactError(ContactError.OPERATION_CANCELLED_ERROR);
+                cancelledError.message = "User did not pick a contact.";
+                fail(cancelledError);
                 return;
             }
             // If we are on desktop, just send em back

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -478,6 +478,7 @@ exports.defineAutoTests = function() {
                 expect(ContactError.PENDING_OPERATION_ERROR).toBe(3);
                 expect(ContactError.IO_ERROR).toBe(4);
                 expect(ContactError.NOT_SUPPORTED_ERROR).toBe(5);
+                expect(ContactError.OPERATION_CANCELLED_ERROR).toBe(6);
                 expect(ContactError.PERMISSION_DENIED_ERROR).toBe(20);
             });
         });
@@ -537,7 +538,9 @@ exports.defineManualTests = function(contentEl, createActionButton) {
             function (e) {
                 results.innerHTML = (e && e.code === ContactError.NOT_SUPPORTED_ERROR) ?
                     "Searching for contacts is not supported." :
-                    "Pick failed: error " + (e && e.code);
+                    (e && e.code === ContactError.OPERATION_CANCELLED_ERROR) ?
+                        "Pick cancelled" :
+                        "Pick failed: error " + (e && e.code);
             }
         );
     }

--- a/www/ContactError.js
+++ b/www/ContactError.js
@@ -37,6 +37,7 @@ ContactError.TIMEOUT_ERROR = 2;
 ContactError.PENDING_OPERATION_ERROR = 3;
 ContactError.IO_ERROR = 4;
 ContactError.NOT_SUPPORTED_ERROR = 5;
+ContactError.OPERATION_CANCELLED_ERROR = 6;
 ContactError.PERMISSION_DENIED_ERROR = 20;
 
 module.exports = ContactError;


### PR DESCRIPTION
Also introduce OPERATION_CANCELLED_ERROR as an error code for reporting contact picker cancellation.

See [CB-8156](https://issues.apache.org/jira/browse/CB-8156) for details