### PR TITLE
CB-7906 Prevent app crash when desiredFields option has undefined items

### DIFF
--- a/src/ios/CDVContact.m
+++ b/src/ios/CDVContact.m
@@ -1377,6 +1377,10 @@ static NSDictionary* org_apache_cordova_contacts_defaultFields = nil;
         }
 
         for (id i in fieldsArray) {
+
+            // CB-7906 ignore NULL desired fields to avoid fatal exception
+            if ([i isKindOfClass:[NSNull class]]) continue;
+
             NSMutableArray* keys = nil;
             NSString* fieldStr = nil;
             if ([i isKindOfClass:[NSNumber class]]) {


### PR DESCRIPTION
This is a fix for [CB-7906](https://issues.apache.org/jira/browse/CB-7906) 