### PR TITLE
CB-10159 android: Adding restore callback to handle Activity destruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,27 @@ function specified by the __contactSuccess__ parameter.
             console.log('Error: ' + err);
         });
 
+### Android Quirks
+
+This plugin launches an external Activity for picking contacts. See the
+[Android Lifecycle Guide](http://cordova.apache.org/docs/en/dev/guide/platforms/android/lifecycle.html)
+for an explanation of how this affects your application. If the plugin returns
+its result in the `resume` event, then you must first wrap the returned object
+in a `Contact` object before using it. Here is an example:
+
+```javascript
+function onResume(resumeEvent) {
+    if(resumeEvent.pendingResult) {
+        if(resumeEvent.pendingResult.pluginStatus === "OK") {
+            var contact = navigator.contacts.create(resumeEvent.pendingResult.result);
+            successCallback(contact);
+        } else {
+            failCallback(resumeEvent.pendingResult.result);
+        }
+    }
+}
+```
+
 ## Contact
 
 The `Contact` object represents a user's contact.  Contacts can be

--- a/src/android/ContactManager.java
+++ b/src/android/ContactManager.java
@@ -32,6 +32,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.os.Build;
+import android.os.Bundle;
 import android.provider.ContactsContract.Contacts;
 import android.provider.ContactsContract.RawContacts;
 import android.util.Log;
@@ -292,4 +293,14 @@ public class ContactManager extends CordovaPlugin {
         }
     }
 
+    /**
+     * This plugin launches an external Activity when a contact is picked, so we
+     * need to implement the save/restore API in case the Activity gets killed
+     * by the OS while it's in the background. We don't actually save anything
+     * because picking a contact doesn't take in any arguments.
+     */
+    public void onRestoreStateForActivityResult(Bundle state, CallbackContext callbackContext) {
+        this.callbackContext = callbackContext;
+        this.contactAccessor = new ContactAccessorSdk5(this.cordova);
+    }
 }


### PR DESCRIPTION
Implementing the new plugin save/restore API to fix a crash that happened when the OS killed the Cordova Activity while the contact picking Activity is in the foreground. Tested on a Marshmallow device and a Lollipop emulator.