### PR TITLE
CB-10319 android: Adding reflective helper methods for permission requests

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -33,10 +33,6 @@
     <repo>https://git-wip-us.apache.org/repos/asf/cordova-plugin-contacts.git</repo>
     <issue>https://issues.apache.org/jira/browse/CB/component/12320652</issue>
 
-    <engines>
-      <engine name="cordova-android" version=">=5.0.0-dev" />
-    </engines>
-
     <js-module src="www/contacts.js" name="contacts">
         <clobbers target="navigator.contacts" />
     </js-module>
@@ -91,6 +87,7 @@
         <source-file src="src/android/ContactAccessorSdk5.java" target-dir="src/org/apache/cordova/contacts" />
         <source-file src="src/android/ContactManager.java" target-dir="src/org/apache/cordova/contacts" />
         <source-file src="src/android/ContactInfoDTO.java" target-dir="src/org/apache/cordova/contacts" />
+        <source-file src="src/android/PermissionHelper.java" target-dir="src/org/apache/cordova/contacts" />
     </platform>
 
     <!-- amazon-fireos -->
@@ -111,7 +108,7 @@
         <source-file src="src/android/ContactAccessorSdk5.java" target-dir="src/org/apache/cordova/contacts" />
         <source-file src="src/android/ContactManager.java" target-dir="src/org/apache/cordova/contacts" />
     </platform>
-    
+
     <!-- ubuntu -->
     <platform name="ubuntu">
         <config-file target="config.xml" parent="/*">
@@ -192,7 +189,7 @@
         <source-file src="src/wp/ContactPicker.xaml.cs" />
         <source-file src="src/wp/ContactPickerTask.cs" />
     </platform>
-    
+
     <!-- firefoxos -->
     <platform name="firefoxos">
         <config-file target="config.xml" parent="/*">
@@ -202,7 +199,7 @@
         <js-module src="src/firefoxos/ContactsProxy.js" name="ContactsProxy">
             <runs />
         </js-module>
-    </platform>    
+    </platform>
 
     <!-- Windows 8 -->
     <platform name="windows8">

--- a/src/android/ContactManager.java
+++ b/src/android/ContactManager.java
@@ -78,13 +78,13 @@ public class ContactManager extends CordovaPlugin {
 
     protected void getReadPermission(int requestCode)
     {
-        cordova.requestPermission(this, requestCode, READ);
+        PermissionHelper.requestPermission(this, requestCode, READ);
     }
 
 
     protected void getWritePermission(int requestCode)
     {
-        cordova.requestPermission(this, requestCode, WRITE);
+        PermissionHelper.requestPermission(this, requestCode, WRITE);
     }
 
 
@@ -119,7 +119,7 @@ public class ContactManager extends CordovaPlugin {
         }
 
         if (action.equals("search")) {
-            if(cordova.hasPermission(READ)) {
+            if(PermissionHelper.hasPermission(this, READ)) {
                 search(executeArgs);
             }
             else
@@ -128,7 +128,7 @@ public class ContactManager extends CordovaPlugin {
             }
         }
         else if (action.equals("save")) {
-            if(cordova.hasPermission(WRITE))
+            if(PermissionHelper.hasPermission(this, WRITE))
             {
                 save(executeArgs);
             }
@@ -138,7 +138,7 @@ public class ContactManager extends CordovaPlugin {
             }
         }
         else if (action.equals("remove")) {
-            if(cordova.hasPermission(WRITE))
+            if(PermissionHelper.hasPermission(this, WRITE))
             {
                 remove(executeArgs);
             }
@@ -148,7 +148,7 @@ public class ContactManager extends CordovaPlugin {
             }
         }
         else if (action.equals("pickContact")) {
-            if(cordova.hasPermission(READ))
+            if(PermissionHelper.hasPermission(this, READ))
             {
                 pickContactAsync();
             }

--- a/src/android/PermissionHelper.java
+++ b/src/android/PermissionHelper.java
@@ -1,0 +1,138 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+package org.apache.cordova.contacts;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.apache.cordova.CordovaInterface;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.LOG;
+
+import android.content.pm.PackageManager;
+
+/**
+ * This class provides reflective methods for permission requesting and checking so that plugins
+ * written for cordova-android 5.0.0+ can still compile with earlier cordova-android versions.
+ */
+public class PermissionHelper {
+    private static final String LOG_TAG = "CordovaPermissionHelper";
+
+    /**
+     * Requests a "dangerous" permission for the application at runtime. This is a helper method
+     * alternative to cordovaInterface.requestPermission() that does not require the project to be
+     * built with cordova-android 5.0.0+
+     *
+     * @param plugin        The plugin the permission is being requested for
+     * @param requestCode   A requestCode to be passed to the plugin's onRequestPermissionResult()
+     *                      along with the result of the permission request
+     * @param permission    The permission to be requested
+     */
+    public static void requestPermission(CordovaPlugin plugin, int requestCode, String permission) {
+        PermissionHelper.requestPermissions(plugin, requestCode, new String[] {permission});
+    }
+
+    /**
+     * Requests "dangerous" permissions for the application at runtime. This is a helper method
+     * alternative to cordovaInterface.requestPermissions() that does not require the project to be
+     * built with cordova-android 5.0.0+
+     *
+     * @param plugin        The plugin the permissions are being requested for
+     * @param requestCode   A requestCode to be passed to the plugin's onRequestPermissionResult()
+     *                      along with the result of the permissions request
+     * @param permissions   The permissions to be requested
+     */
+    public static void requestPermissions(CordovaPlugin plugin, int requestCode, String[] permissions) {
+        try {
+            Method requestPermission = CordovaInterface.class.getDeclaredMethod(
+                    "requestPermissions", CordovaPlugin.class, int.class, String[].class);
+
+            // If there is no exception, then this is cordova-android 5.0.0+
+            requestPermission.invoke(plugin.cordova, plugin, requestCode, permissions);
+        } catch (NoSuchMethodException noSuchMethodException) {
+            // cordova-android version is less than 5.0.0, so permission is implicitly granted
+            LOG.d(LOG_TAG, "No need to request permissions " + Arrays.toString(permissions));
+
+            // Notify the plugin that all were granted by using more reflection
+            deliverPermissionResult(plugin, requestCode, permissions);
+        } catch (IllegalAccessException illegalAccessException) {
+            // Should never be caught; this is a public method
+            LOG.e(LOG_TAG, "IllegalAccessException when requesting permissions " + Arrays.toString(permissions), illegalAccessException);
+        } catch(InvocationTargetException invocationTargetException) {
+            // This method does not throw any exceptions, so this should never be caught
+            LOG.e(LOG_TAG, "invocationTargetException when requesting permissions " + Arrays.toString(permissions), invocationTargetException);
+        }
+    }
+
+    /**
+     * Checks at runtime to see if the application has been granted a permission. This is a helper
+     * method alternative to cordovaInterface.hasPermission() that does not require the project to
+     * be built with cordova-android 5.0.0+
+     *
+     * @param plugin        The plugin the permission is being checked against
+     * @param permission    The permission to be checked
+     *
+     * @return              True if the permission has already been granted and false otherwise
+     */
+    public static boolean hasPermission(CordovaPlugin plugin, String permission) {
+        try {
+            Method hasPermission = CordovaInterface.class.getDeclaredMethod("hasPermission", String.class);
+
+            // If there is no exception, then this is cordova-android 5.0.0+
+            return (Boolean) hasPermission.invoke(plugin.cordova, permission);
+        } catch (NoSuchMethodException noSuchMethodException) {
+            // cordova-android version is less than 5.0.0, so permission is implicitly granted
+            LOG.d(LOG_TAG, "No need to check for permission " + permission);
+            return true;
+        } catch (IllegalAccessException illegalAccessException) {
+            // Should never be caught; this is a public method
+            LOG.e(LOG_TAG, "IllegalAccessException when checking permission " + permission, illegalAccessException);
+        } catch(InvocationTargetException invocationTargetException) {
+            // This method does not throw any exceptions, so this should never be caught
+            LOG.e(LOG_TAG, "invocationTargetException when checking permission " + permission, invocationTargetException);
+        }
+        return false;
+    }
+
+    private static void deliverPermissionResult(CordovaPlugin plugin, int requestCode, String[] permissions) {
+        // Generate the request results
+        int[] requestResults = new int[permissions.length];
+        Arrays.fill(requestResults, PackageManager.PERMISSION_GRANTED);
+
+        try {
+            Method onRequestPermissionResult = CordovaPlugin.class.getDeclaredMethod(
+                    "onRequestPermissionResult", int.class, String[].class, int[].class);
+
+            onRequestPermissionResult.invoke(plugin, requestCode, permissions, requestResults);
+        } catch (NoSuchMethodException noSuchMethodException) {
+            // Should never be caught since the plugin must be written for cordova-android 5.0.0+ if it
+            // made it to this point
+            LOG.e(LOG_TAG, "NoSuchMethodException when delivering permissions results", noSuchMethodException);
+        } catch (IllegalAccessException illegalAccessException) {
+            // Should never be caught; this is a public method
+            LOG.e(LOG_TAG, "IllegalAccessException when delivering permissions results", illegalAccessException);
+        } catch(InvocationTargetException invocationTargetException) {
+            // This method may throw a JSONException. We are just duplicating cordova-android's
+            // exception handling behavior here; all it does is log the exception in CordovaActivity,
+            // print the stacktrace, and ignore it
+            LOG.e(LOG_TAG, "InvocationTargetException when delivering permissions results", invocationTargetException);
+        }
+    }
+}


### PR DESCRIPTION
Adds reflective helper class so that plugins written for cordova-android 5.0.0+ can still build with earlier versions. This was tested by running mobilespec auto and manual tests on an Android Marshmallow device with cordova-android's master branch and cordova-android 3.7.2. @infil00p @jasongin please review.