### PR TITLE
chore: edit package.json license to match SPDX id

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,5 @@
     "cordova-windows"
   ],
   "author": "Apache Software Foundation",
-  "license": "Apache 2.0"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
See [NPM package.json spec for licenses](https://docs.npmjs.com/files/package.json#license) and [SPDX license IDs](https://spdx.org/licenses/)

X-ref: https://github.com/apache/cordova-plugin-device/pull/48