### PR TITLE
CB-10632: Fixing jasmine test contact removal

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -49,7 +49,7 @@ exports.defineAutoTests = function() {
             gContactObj = null;
             done();
         }, function() {
-            done();
+            fail(done);
         });
     };
 
@@ -545,9 +545,10 @@ exports.defineAutoTests = function() {
                 gContactObj = new Contact();
                 gContactObj.name = new ContactName();
                 gContactObj.name.familyName = contactName;
+                gContactObj.note = "DeleteMe";
                 saveAndFindBy(["displayName", "name"], contactName, done);
             }, MEDIUM_TIMEOUT);
-            
+
             it("contacts.spec.26 Creating, saving, finding a contact should work, removing it should work", function(done) {
                 // Save method is not supported on Windows platform
                 if (isWindows || isWindowsPhone8 || isIOSPermissionBlocked) {
@@ -557,15 +558,17 @@ exports.defineAutoTests = function() {
                 gContactObj = new Contact();
                 gContactObj.name = new ContactName();
                 gContactObj.name.familyName = contactName;
+                gContactObj.note = "DeleteMe";
                 saveAndFindBy(["displayName", "name"], contactName, function() {
                     gContactObj.remove(function() {
+                        gContactObj = null;
                         done();
                     }, function(e) {
                         throw ("Newly created contact's remove function invoked error callback. Test failed.");
                     });
                 });
             }, MEDIUM_TIMEOUT);
-            
+
             it("contacts.spec.27 Should not be able to delete the same contact twice", function(done) {
                 // Save method is not supported on Windows platform
                 if (isWindows || isWindowsPhone8 || isIOSPermissionBlocked) {
@@ -575,6 +578,7 @@ exports.defineAutoTests = function() {
                 gContactObj = new Contact();
                 gContactObj.name = new ContactName();
                 gContactObj.name.familyName = contactName;
+                gContactObj.note = "DeleteMe";
                 saveAndFindBy(["displayName", "name"], contactName, function() {
                     gContactObj.remove(function() {
                         var findWin = function(seas) {
@@ -582,6 +586,7 @@ exports.defineAutoTests = function() {
                             gContactObj.remove(function() {
                                 throw ("Success callback called after non-existent Contact object called remove(). Test failed.");
                             }, function(e) {
+                                gContactObj = null;
                                 expect(e.code).toBe(ContactError.UNKNOWN_ERROR);
                                 done();
                             });
@@ -612,14 +617,14 @@ exports.defineAutoTests = function() {
                 if (isWindows || isWindowsPhone8) {
                     pending();
                 }
-    
+
                 gContactObj = new Contact();
                 var phoneNumbers = [1];
                 phoneNumbers[0] = new ContactField('work', '555-555-1234', true);
                 gContactObj.phoneNumbers = phoneNumbers;
-                
+
                 saveAndFindBy(["phoneNumbers"], "555-555-1234", done);
-    
+
             }, MEDIUM_TIMEOUT);
         });
 
@@ -705,7 +710,7 @@ exports.defineManualTests = function(contentEl, createActionButton) {
             }
         );
     }
-    
+
     function addContact(displayName, name, phoneNumber, birthday) {
         try {
             var results = document.getElementById('contact_results');

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -48,8 +48,10 @@ exports.defineAutoTests = function() {
         gContactObj.remove(function() {
             gContactObj = null;
             done();
-        }, function() {
-            fail(done);
+        }, function(contactError) {
+            // Because Jasmine won't print the error otherwise
+            expect(contactError).toBeUndefined();
+            done();
         });
     };
 


### PR DESCRIPTION
This is related to the flaky tests that have been failing in the android-win CI. As the jasmine tests execute, they create contacts and occasionally fail to remove them. When that happens, the created contacts will never be removed and all of the tests that depend on those contacts not existing will fail until someone manually deletes the contacts on the emulator. This PR does not fix the test flakiness issue, but does fix the issue of the tests being permanently broken by a single failure. It also makes it so that the removal failures will actually be reported by jasmine where they were not previously so that we can hopefully pinpoint the real issue and fix the flaky test in a later PR.