### PR TITLE
Disable 'calendar permissions request prompt' during automated testing

### DIFF
--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -28,4 +28,9 @@
 
     <js-module src="tests.js" name="tests">
     </js-module>
+    <config-file target="*-Info.plist" parent="com.apple.private.tcc.allow.overridable">
+        <array>
+            <string>kTCCServiceAddressBook</string>
+        </array>
+    </config-file>
 </plugin>


### PR DESCRIPTION
Work In Progress

This modification will add the following snippet to 'mobilespec-Info.plist', with the goal being to suppress the iOS permissions prompt for contacts:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>com.apple.private.tcc.allow.overridable</key>
    <array>
        <string>kTCCServiceAddressBook</string>
    </array>
</dict>
</plist>
```
