### PR TITLE
CB-11043: Android App crashes while trying to save contact with phone numbers array with deleted values

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,6 @@ for details.
     myContact.save(function (contact_obj) {
         var contactObjToModify = contact_obj.clone();
         contact_obj.remove(function(){
-            // Note: Do NOT use delete operator to remove the phone numbers. It will break in android.
             var phoneNumbers = [contactObjToModify.phoneNumbers[0]];
             contactObjToModify.phoneNumbers = phoneNumbers;
             contactObjToModify.save(function(c_obj){

--- a/src/android/ContactAccessorSdk5.java
+++ b/src/android/ContactAccessorSdk5.java
@@ -1701,8 +1701,10 @@ public class ContactAccessorSdk5 extends ContactAccessor {
             phones = contact.getJSONArray("phoneNumbers");
             if (phones != null) {
                 for (int i = 0; i < phones.length(); i++) {
-                    JSONObject phone = (JSONObject) phones.get(i);
-                    insertPhone(ops, phone);
+                    if(!phones.isNull(i)){
+                        JSONObject phone = (JSONObject) phones.get(i);
+                        insertPhone(ops, phone);
+                    }
                 }
             }
         } catch (JSONException e) {


### PR DESCRIPTION
If you use delete operator to remove the phone numbers in a phone number array and then save it, there will be a runtime exception in android. (In iOS it is already working fine). This fix will resolve the issue in android. 

@nikhilkh @riknoll @rakatyal Can you review and merge this PR?