### PR TITLE
Resolved crash in Samsung S6 and S7. See CB-11206.

### DIFF
--- a/src/android/ContactAccessorSdk5.java
+++ b/src/android/ContactAccessorSdk5.java
@@ -904,7 +904,7 @@ public class ContactAccessorSdk5 extends ContactAccessor {
             im.put("id", cursor.getString(cursor.getColumnIndex(CommonDataKinds.Im._ID)));
             im.put("pref", false); // Android does not store pref attribute
             im.put("value", cursor.getString(cursor.getColumnIndex(CommonDataKinds.Im.DATA)));
-            im.put("type", getImType(Integer.parseInt(cursor.getString(cursor.getColumnIndex(CommonDataKinds.Im.PROTOCOL)))));
+            im.put("type", getImType(Integer.parseInt(cursor.getString(cursor.getColumnIndex(CommonDataKinds.Im.CUSTOM_PROTOCOL)))));
         } catch (JSONException e) {
             Log.e(LOG_TAG, e.getMessage(), e);
         }


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
Fixes crash on Samsung S6, S7 possible on other Samsung models.  See [JIRA issue here](https://issues.apache.org/jira/browse/CB-11206)

### What testing has been done on this change?
Samsung S5, S6, S7, Nexus 5, 9, Samsung GT-S630T, Vodafone VF695 and at least 5 other relevant emulators.

We are looking forward to this pull request being merged back to develop. It's working pretty well on a couple of apps where we use this Cordova plugin.

