### PR TITLE
CB-11455: (ios) Add mandatory iOS 10 privacy description

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -132,6 +132,10 @@
             </feature>
         </config-file>
 
+        <config-file target="*-Info.plist" parent="NSContactsUsageDescription">
+            <string></string>
+        </config-file>
+
         <js-module src="www/ios/contacts.js" name="contacts-ios">
             <merges target="navigator.contacts" />
         </js-module>


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Adds mandatory iOS 10 privacy description; since iOS 6 Apple provided a way to show the user why a certain permission is required. In iOS 10 this becomes mandatory, so any app not specifying the key will crash at runtime when a permissions is requested.

This plugin requests the Contacts permission, so at the very least we need to add `NSContactsUsageDescription` to the `plist`.

Note that this is the same approach as the Geolocation plugin has taken a while ago.

### What testing has been done on this change?
Deployed this plugin in an app on iOS 10 (developer preview) which crashed as expect upon permission request. After adding the `plist` key the crash disappeared and since the value of the description is empty the UI is the same as before. It is recommended by Apple though to actually provide a description. But at least this is way better than a crash :)

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database: https://issues.apache.org/jira/browse/CB-11455
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
