### PR TITLE
CB-11455: (ios) Add mandatory iOS 10 privacy description

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ It is also possible to install via repo url directly ( unstable )
     cordova plugin add https://github.com/apache/cordova-plugin-contacts.git
 
 
+### iOS Quirks
+
+Since iOS 10 it's mandatory to add a `NSContactsUsageDescription` entry in the info.plist.
+
+`NSContactsUsageDescription` describes the reason that the app accesses the user’s contacts. When the system prompts the user to allow access, this string is displayed as part of the dialog box. To add this entry you can pass the variable `CONTACTS_USAGE_DESCRIPTION` on plugin install.
+
+Example:
+`cordova plugin add cordova-plugin-contacts --variable CONTACTS_USAGE_DESCRIPTION="your usage message"`
+
+If you don't pass the variable, the plugin will add an empty string as value.
+
 ### Firefox OS Quirks
 
 Create __www/manifest.webapp__ as described in

--- a/plugin.xml
+++ b/plugin.xml
@@ -132,6 +132,11 @@
             </feature>
         </config-file>
 
+        <preference name="CONTACTS_USAGE_DESCRIPTION" default=" " />
+        <config-file target="*-Info.plist" parent="NSContactsUsageDescription">
+            <string>$CONTACTS_USAGE_DESCRIPTION</string>
+        </config-file>
+
         <js-module src="www/ios/contacts.js" name="contacts-ios">
             <merges target="navigator.contacts" />
         </js-module>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Adds the mandatory `NSContactsUsageDescription` key to the info.plist, allowing to pass the value as a variable.
Documented the usage of the variable on plugin install as iOS quirk

### What testing has been done on this change?
Tested on iOS 10 device

### Checklist
- [X] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

