### PR TITLE
CB-11350 android: retrieve displayName for contact when specified in desiredFields

### DIFF
--- a/src/android/ContactAccessorSdk5.java
+++ b/src/android/ContactAccessorSdk5.java
@@ -406,7 +406,7 @@ public class ContactAccessorSdk5 extends ContactAccessor {
                     // Grab the mimetype of the current row as it will be used in a lot of comparisons
                     mimetype = c.getString(colMimetype);
 
-                    if (mimetype.equals(CommonDataKinds.StructuredName.CONTENT_ITEM_TYPE) && isRequired("name", populate)) {
+                    if (mimetype.equals(CommonDataKinds.StructuredName.CONTENT_ITEM_TYPE) && isRequired("displayName", populate)) {
                         contact.put("displayName", c.getString(colDisplayName));
                     }
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -252,6 +252,35 @@ exports.defineAutoTests = function() {
 
                     specContext.contactObj.save(test, fail.bind(null, done));
                 });
+
+                it("contacts.spec.7.1 should contain displayName if specified in desiredFields", function(done) {
+                    if (isWindows || isWindowsPhone8 || isIOSPermissionBlocked) {
+                        pending();
+                    }
+                    var testDisplayName = "testContact";
+                    var specContext = this;
+                    specContext.contactObj = new Contact();
+                    specContext.contactObj.displayName = testDisplayName;
+
+                    var win = function(contactResult) {
+                        expect(contactResult.length > 0).toBe(true);
+                        var namesDisplayed = contactResult.every(function(contact, index) {
+                            return contact.displayName !== null;
+                        });
+                        expect(namesDisplayed).toBe(true);
+                        done();
+                    };
+
+                    var onSuccessSave = function(savedContact) {
+                        specContext.contactObj = savedContact;
+                        var options = new ContactFindOptions();
+                        options.filter = testDisplayName;
+                        options.multiple = true;
+                        options.desiredFields = [navigator.contacts.fieldType.displayName];
+                        navigator.contacts.find(["displayName", "nickname"], win, fail.bind(null, done), options);
+                    };
+                    specContext.contactObj.save(onSuccessSave, fail.bind(null, done));
+                });
             });
         });
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
DisplayName wasn't being retrieved because of wrong condition in populateContactArray. This PR allows to retrieve displayName for contact when specified in desiredFields.

### What testing has been done on this change?
Auto test

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.

