### PR TITLE
CB-11975 iOS: Search on contacts' id with number type

### DIFF
--- a/src/ios/CDVContacts.m
+++ b/src/ios/CDVContacts.m
@@ -330,7 +330,9 @@
             NSArray* desiredFields = nil;
             if (![findOptions isKindOfClass:[NSNull class]]) {
                 id value = nil;
-                filter = (NSString*)[findOptions objectForKey:@"filter"];
+                id filterValue = [findOptions objectForKey:@"filter"];
+                BOOL filterValueIsNumber = [filterValue isKindOfClass:[NSNumber class]];
+                filter = filterValueIsNumber ? [filterValue stringValue] : (NSString *) filterValue;
                 value = [findOptions objectForKey:@"multiple"];
                 if ([value isKindOfClass:[NSNumber class]]) {
                     // multiple is a boolean that will come through as an NSNumber

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -281,6 +281,27 @@ exports.defineAutoTests = function() {
                     };
                     specContext.contactObj.save(onSuccessSave, fail.bind(null, done));
                 });
+                it("contacts.spec.7.2 should find contact despite id isn't string ", function(done) {
+                    if (isWindows || isWindowsPhone8 || isIOSPermissionBlocked) {
+                        pending();
+                    }
+                    var testDisplayName = "testContact";
+                    var specContext = this;
+                    specContext.contactObj = new Contact();
+                    specContext.contactObj.displayName = testDisplayName;
+                    var win = function(contactResult) {
+                        expect(contactResult.length > 0).toBe(true);
+                        done();
+                    };
+                    var onSuccessSave = function(savedContact) {
+                        specContext.contactObj = savedContact;
+                        var options = new ContactFindOptions();
+                        options.filter = savedContact.id;
+                        options.multiple = true;
+                        navigator.contacts.find(["id"], win, fail.bind(null, done), options);
+                    };
+                    specContext.contactObj.save(onSuccessSave, fail.bind(null, done));
+                });
             });
         });
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->
### Platforms affected

iOS
### What does this PR do?

There was crash when user passed id of numeric type. This PR makes possible to search for contact by id either string or numeric type as well as on Android platform.
### What testing has been done on this change?

Auto test
### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
