### PR TITLE
android doesn't support data to save photo for contact by image data …

### DIFF
--- a/src/android/ContactAccessorSdk5.java
+++ b/src/android/ContactAccessorSdk5.java
@@ -1649,6 +1649,21 @@ public class ContactAccessorSdk5 extends ContactAccessor {
      * @throws IOException
      */
     private InputStream getPathFromUri(String path) throws IOException {
+        if (path.startsWith("data:")) { // data:image/png;base64,[ENCODED_IMAGE]
+            String dataInfos = path.substring(0, path.indexOf(','));
+            dataInfos = dataInfos.substring(dataInfos.indexOf(':') + 1);
+            String baseEncoding = dataInfos.substring(dataInfos.indexOf(';') + 1);
+            // [ENCODED_IMAGE]
+            if("base64".equalsIgnoreCase(baseEncoding)) {
+                String img = path.substring(path.indexOf(',') + 1); 
+                byte[] encodedData = img.getBytes();
+                ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(encodedData, 0, encodedData.length);
+                Base64InputStream base64InputStream = new Base64InputStream(byteArrayInputStream, Base64.DEFAULT);
+                return base64InputStream;
+            } else {
+                Log.w(LOG_TAG, "Could not decode image. The found base encoding is " + baseEncoding);
+            }
+        }  
         if (path.startsWith("content:")) {
             Uri uri = Uri.parse(path);
             return mApp.getActivity().getContentResolver().openInputStream(uri);

--- a/src/android/ContactAccessorSdk5.java
+++ b/src/android/ContactAccessorSdk5.java
@@ -55,7 +55,8 @@ import android.provider.ContactsContract;
 import android.provider.ContactsContract.CommonDataKinds;
 import android.provider.ContactsContract.CommonDataKinds.Phone;
 import android.text.TextUtils;
-
+import android.util.Base64;
+import android.util.Base64InputStream;
 /**
  * An implementation of {@link ContactAccessor} that uses current Contacts API.
  * This class should be used on Eclair or beyond, but would not work on any earlier

--- a/src/android/ContactAccessorSdk5.java
+++ b/src/android/ContactAccessorSdk5.java
@@ -19,6 +19,7 @@
 
 package org.apache.cordova.contacts;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;

--- a/src/android/ContactAccessorSdk5.java
+++ b/src/android/ContactAccessorSdk5.java
@@ -1662,7 +1662,7 @@ public class ContactAccessorSdk5 extends ContactAccessor {
                 Base64InputStream base64InputStream = new Base64InputStream(byteArrayInputStream, Base64.DEFAULT);
                 return base64InputStream;
             } else {
-                Log.w(LOG_TAG, "Could not decode image. The found base encoding is " + baseEncoding);
+                LOG.d(LOG_TAG, "Could not decode image. The found base encoding is " + baseEncoding);
             }
         }  
         if (path.startsWith("content:")) {


### PR DESCRIPTION
### Platforms affected

Android
### What does this PR do?

Fixes a problem that is not supported to save data base64 to be able to save for contact photo.
### What testing has been done on this change?

Tested on Samsung Galaxy Note3, Android 4.4 Emulator

PS
 This is not my own source code but I think anyone didn't reflect this solution for it. 
 I referred it from https://groups.google.com/forum/#!msg/phonegap/jTMu9Azjaa8/ywQMMEcoS1YJ.
 I just wanted to fix this issue. That's why I am doing this.
