### PR TITLE
CB-12300: fix tests failure when running it using jasmine-node

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -692,7 +692,9 @@ exports.defineAutoTests = function() {
                 contact.name = new ContactName();
                 contact.name.familyName = contactName;
                 contact.note = "DeleteMe";
-                saveAndFindBy(contact, ["displayName", "name"], contactName, done, this);
+                saveAndFindBy(contact, ["displayName", "name"], contactName, function() {
+                    done();
+                }, this);
             }, MEDIUM_TIMEOUT);
 
             it("contacts.spec.26 Creating, saving, finding a contact should work, removing it should work", function(done) {
@@ -757,7 +759,9 @@ exports.defineAutoTests = function() {
                 contact.note = "DeleteMe";
                 contact.name = new ContactName();
                 contact.name.familyName = contactName;
-                saveAndFindBy(contact, ["displayName", "name"], contactName, done, this);
+                saveAndFindBy(contact, ["displayName", "name"], contactName, function() {
+                    done();
+                }, this);
             }, MEDIUM_TIMEOUT);
 
             it("contacts.spec.29 should find a contact without a name", function (done) {
@@ -771,7 +775,9 @@ exports.defineAutoTests = function() {
                 phoneNumbers[0] = new ContactField('work', '555-555-1234', true);
                 contact.phoneNumbers = phoneNumbers;
 
-                saveAndFindBy(contact, ["phoneNumbers"], "555-555-1234", done, this);
+                saveAndFindBy(contact, ["phoneNumbers"], "555-555-1234", function() {
+                    done();
+                }, this);
 
             }, MEDIUM_TIMEOUT);
 


### PR DESCRIPTION
### Platforms affected
None

### What does this PR do?
This PR allows to run this project jasmine tests using [jasmine-node](https://github.com/mhevery/jasmine-node)
In nodejs convention when calling async test done() function with parameter it consider it as error object and the test fails.
In this project on the following tests the done function is eventually called with a parameter:
contacts.spec.25
contacts.spec.28
contacts.spec.29

If you'll run these tests with jasmine-node you'll get the following error:
`Message:
     [object Object]
   Stacktrace:
     undefined`

 This PR fixes it by sending own callback that calls done as expected

### What testing has been done on this change?
Run the test :)

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
