### PR TITLE
CB-12982: (Android, iOS) Appium tests: try to create a session harder

### DIFF
--- a/appium-tests/common/common.spec.js
+++ b/appium-tests/common/common.spec.js
@@ -247,7 +247,15 @@ describe('Contacts UI Automation Tests', function () {
     }, MINUTE);
 
     it('should connect to an appium endpoint properly', function (done) {
+        // retry up to 3 times
         getDriver()
+            .fail(function () {
+                return getDriver()
+                    .fail(function () {
+                        return getDriver()
+                            .fail(fail);
+                    });
+            })
             .then(function () {
                 failedToStart = false;
             }, fail)
@@ -318,7 +326,7 @@ describe('Contacts UI Automation Tests', function () {
                     });
             })
             .done(done);
-    }, 10 * MINUTE);
+    }, 30 * MINUTE);
 
     describe('Picking contacts', function () {
         afterEach(function (done) {


### PR DESCRIPTION
### Platforms affected
Android, iOS

### What does this PR do?
https://issues.apache.org/jira/browse/CB-12982
Tries harder to create a session by increasing the timeout and introducing a retry mechanic.

### What testing has been done on this change?
A couple of runs with SauceLabs concurrency meter being 5/5.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
