### PR TITLE
Updated windows ContactProxy.js

### DIFF
--- a/src/windows/ContactProxy.js
+++ b/src/windows/ContactProxy.js
@@ -404,6 +404,10 @@ module.exports = {
 
         // When contact store retrieved
         contactStoreRequest.done(function (contactStore) {
+            // check if contactStore is not null object
+            if (!contactStore) {
+                return fail(new ContactError(ContactError.UNKNOWN_ERROR));
+            }
             // determine, which function we use depending on whether searchOptions.filter specified or not
             var contactsRequest = searchFilter ? contactStore.findContactsAsync(searchFilter) : contactStore.findContactsAsync();
             // request contacts and resolve either with success or error callback


### PR DESCRIPTION
### Platforms affected

Windows

### Motivation and Context

When on windows user decline "Permissions request" prompt, the app immediately crashes since `contactStoreRequest` callback argument is `null`, so lib throws an error which can't be handled from an app level. Every next app open end up with crash too, until the user manually allow contacts permission for the app



### Description

Added simple `if` which checks if `contactStoreRequest` callback argument is not `null`


### Testing

Tested on Windows 10 using VS debug feature, the app doesn't crash anymore

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
