### PR TITLE
Fixed for Android 8.0

### DIFF
--- a/src/android/ContactManager.java
+++ b/src/android/ContactManager.java
@@ -130,7 +130,7 @@ public class ContactManager extends CordovaPlugin {
             }
         }
         else if (action.equals("save")) {
-            if(PermissionHelper.hasPermission(this, WRITE))
+            if(PermissionHelper.hasPermission(this, WRITE) && PermissionHelper.hasPermission(this, READ))
             {
                 save(executeArgs);
             }
@@ -140,7 +140,7 @@ public class ContactManager extends CordovaPlugin {
             }
         }
         else if (action.equals("remove")) {
-            if(PermissionHelper.hasPermission(this, WRITE))
+            if(PermissionHelper.hasPermission(this, WRITE) && PermissionHelper.hasPermission(this, READ))
             {
                 remove(executeArgs);
             }
@@ -283,10 +283,12 @@ public class ContactManager extends CordovaPlugin {
                 search(executeArgs);
                 break;
             case SAVE_REQ_CODE:
-                save(executeArgs);
+                if (!PermissionHelper.hasPermission(this, READ)) getReadPermission(SAVE_REQ_CODE);
+                else save(executeArgs);
                 break;
             case REMOVE_REQ_CODE:
-                remove(executeArgs);
+                if (!PermissionHelper.hasPermission(this, READ)) getReadPermission(REMOVE_REQ_CODE);
+                else remove(executeArgs);
                 break;
             case PICK_REQ_CODE:
                 pickContactAsync();


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android 8.0 and above


### Motivation and Context
Android 8.0 no longer assumes related permissions - so when the app gets a contact 'write' permission to save the contact, it no longer automatically gets the 'read' permission - which was causing the app to crash when it tries to read the contact it just saved.



### Description
<!-- Describe your changes in detail -->
This modification simply ensures the app has both permissions before attempting to save or remove.


### Testing
<!-- Please describe in detail how you tested your changes. -->
This update has been tested on Android 8, 9 and 10.

